### PR TITLE
Avatar update

### DIFF
--- a/src/v2/routes/me/index.ts
+++ b/src/v2/routes/me/index.ts
@@ -17,6 +17,7 @@ import {
 import { uploadJPEG } from '../../utils/aws-s3';
 import { loadUser } from '../../utils/session-utils';
 import { assertPassword } from '../../utils/auth';
+import { formatUser } from '../users/utils';
 
 //#region  GET /api/v2/me
 
@@ -56,13 +57,7 @@ async function getMyInfo(req: Request, res: Response, next: NextFunction) {
       error: 0,
       error_msg: 'Me',
       data: {
-        user: {
-          username: data.items[0].username,
-          full_name: data.items[0].full_name,
-          school_name: data.items[0].school_name,
-          email: data.items[0].email,
-          rating: data.items[0].rating,
-        },
+        user: formatUser(data.items[0], false),
       },
     };
     res.json(result);
@@ -78,14 +73,16 @@ async function getMyInfo(req: Request, res: Response, next: NextFunction) {
 type UpdateMyInfoParams = {
   full_name: string;
   school_name: string;
+  avatar: string;
 };
 
 const updateMyInfoParamsSchema: JSONSchemaType<UpdateMyInfoParams> = {
   type: 'object',
-  required: ['full_name', 'school_name'],
+  required: ['full_name', 'school_name', 'avatar'],
   properties: {
     full_name: { type: 'string' },
     school_name: { type: 'string' },
+    avatar: { type: 'string' },
   },
 };
 
@@ -105,7 +102,7 @@ async function updateMyInfo(req: Request, res: Response, next: NextFunction) {
     const user_id = currentUser.user_id;
 
     // 2. Send update request
-    const { full_name, school_name } = assertWithSchema(req.body, updateMyInfoParamsSchema);
+    const { full_name, school_name, avatar } = assertWithSchema(req.body, updateMyInfoParamsSchema);
 
     const updateResponse = await db.users.updateUser({
       where: {
@@ -114,6 +111,7 @@ async function updateMyInfo(req: Request, res: Response, next: NextFunction) {
       values: {
         full_name,
         school_name,
+        avatar,
       },
     });
 
@@ -155,13 +153,7 @@ async function updateMyInfo(req: Request, res: Response, next: NextFunction) {
       error: 0,
       error_msg: 'User updated',
       data: {
-        user: {
-          username: user.username,
-          full_name: user.full_name,
-          school_name: user.school_name,
-          email: user.email,
-          rating: user.rating,
-        },
+        user: formatUser(user, false),
       },
     });
   } catch (error) {

--- a/src/v2/routes/users/index.ts
+++ b/src/v2/routes/users/index.ts
@@ -13,7 +13,7 @@ type GetUserParams = {
 
 const getUserParamsSchema: JSONSchemaType<GetUserParams> = {
   type: 'object',
-  required: ['username', ],
+  required: ['username'],
   properties: {
     username: { type: 'string' },
   },
@@ -46,7 +46,7 @@ async function getUserByUsername(req: Request, res: Response, next: NextFunction
       error_msg: 'User',
       data: {
         user: formatUser(data.items[0], true),
-      }
+      },
     };
     res.json(result);
   } catch (error) {

--- a/src/v2/routes/users/index.ts
+++ b/src/v2/routes/users/index.ts
@@ -2,7 +2,7 @@ import db from '../../utils/database-gateway';
 import { assertWithSchema, JSONSchemaType } from '../../utils/validation';
 import { NextFunction, Request, Response, Router } from 'express';
 import { ERROR_CODE, GeneralError } from '../../utils/common-errors';
-import { getUserIdByUsername, getContestByContestId } from './utils';
+import { getUserIdByUsername, getContestByContestId, formatUser } from './utils';
 import { getTotalParticipationsInContest } from '../../utils/cached-requests';
 
 // #region GET /api/v2/users/:username
@@ -13,7 +13,7 @@ type GetUserParams = {
 
 const getUserParamsSchema: JSONSchemaType<GetUserParams> = {
   type: 'object',
-  required: ['username'],
+  required: ['username', ],
   properties: {
     username: { type: 'string' },
   },
@@ -45,13 +45,8 @@ async function getUserByUsername(req: Request, res: Response, next: NextFunction
       error: 0,
       error_msg: 'User',
       data: {
-        user: {
-          username: data.items[0].username,
-          full_name: data.items[0].full_name,
-          school_name: data.items[0].school_name,
-          rating: data.items[0].rating === undefined ? null : data.items[0].rating,
-        },
-      },
+        user: formatUser(data.items[0], true),
+      }
     };
     res.json(result);
   } catch (error) {

--- a/src/v2/routes/users/utils.ts
+++ b/src/v2/routes/users/utils.ts
@@ -1,5 +1,6 @@
 import db from '../../utils/database-gateway';
 import { ERROR_CODE, GeneralError } from '../../utils/common-errors';
+import { GetUsersData } from '../../utils/database-gateway/users';
 
 export async function getUserIdByUsername(username: string) {
   const { error, error_msg, data } = await db.users.getUsers({
@@ -38,4 +39,21 @@ export async function getContestByContestId(contest_id: number) {
     });
   }
   return { contest: data.items[0] };
+}
+
+export function formatUser(user: GetUsersData['items'][number], hide_email: boolean) {
+  return {
+    username: user.username,
+    full_name: user.full_name,
+    school_name: user.school_name,
+    /*
+    https://github.com/fc5y/user-backend-v2/issues/64:
+    >>> Hàm formatUser cần nhận thêm 1 tham số boolean includeEmail. Nếu tham số này là true thì ko trả về field email
+
+    tạm đổi thành `hide_email` cho rõ nghĩa
+    */
+    email: hide_email ? null : user.email,
+    rating: user.rating === undefined ? null : user.rating,
+    avatar: user.avatar,
+  };
 }

--- a/src/v2/utils/database-gateway/users.ts
+++ b/src/v2/utils/database-gateway/users.ts
@@ -23,6 +23,7 @@ export type GetUsersData = {
     password: string;
     email: string;
     rating: number;
+    avatar: string;
   }>;
 };
 
@@ -44,6 +45,7 @@ const getUsersDataSchema: JSONSchemaType<GetUsersData> = {
           email: { type: 'string' },
           password: { type: 'string' },
           rating: { type: 'number', nullable: true },
+          avatar: { type: 'string', nullable: true },   // should there be a default avatar ?
         },
       },
     },

--- a/src/v2/utils/database-gateway/users.ts
+++ b/src/v2/utils/database-gateway/users.ts
@@ -45,7 +45,7 @@ const getUsersDataSchema: JSONSchemaType<GetUsersData> = {
           email: { type: 'string' },
           password: { type: 'string' },
           rating: { type: 'number', nullable: true },
-          avatar: { type: 'string', nullable: true },   // should there be a default avatar ?
+          avatar: { type: 'string', nullable: true }, // should there be a default avatar ?
         },
       },
     },


### PR DESCRIPTION
Đã tạo hàm `formatUser` tương tự hàm `formatParticipation`/`formatContest`. Hàm này trả về 6 field: `username`, `full_name`, `school_name`, `email`, `rating` và `avatar`.

Đã update các API:

- `GET /api/v2/users/:username`
- `GET /api/v2/me`
- `POST /api/v2/me/update`

`POST /api/v2/me/update` bây giờ requires field 'avatar' trong request body

`type GetUsersData` trong `src/v2/utils/database-gateway/users.ts` có một số thay đổi để thêm vào field 'avatar'